### PR TITLE
[Feature/4] 공통 응답 폼 및 에러 코드 작성

### DIFF
--- a/src/main/java/com/aesp/global/common/code/BaseCode.java
+++ b/src/main/java/com/aesp/global/common/code/BaseCode.java
@@ -1,0 +1,11 @@
+package com.aesp.global.common.code;
+
+import com.aesp.global.common.response.ResponseDto;
+
+public interface BaseCode {
+
+	public ResponseDto.ReasonDto getReason();
+
+	public ResponseDto.ReasonDto getReasonHttpStatus();
+
+}

--- a/src/main/java/com/aesp/global/common/code/BaseCode.java
+++ b/src/main/java/com/aesp/global/common/code/BaseCode.java
@@ -4,8 +4,8 @@ import com.aesp.global.common.response.ResponseDto;
 
 public interface BaseCode {
 
-	public ResponseDto.ReasonDto getReason();
+	ResponseDto.ReasonDto getReason();
 
-	public ResponseDto.ReasonDto getReasonHttpStatus();
+	ResponseDto.ReasonDto getReasonHttpStatus();
 
 }

--- a/src/main/java/com/aesp/global/common/code/BaseErrorCode.java
+++ b/src/main/java/com/aesp/global/common/code/BaseErrorCode.java
@@ -4,8 +4,8 @@ import com.aesp.global.common.response.ResponseDto;
 
 public interface BaseErrorCode {
 
-	public ResponseDto.ErrorReasonDto getReason();
+	ResponseDto.ErrorReasonDto getReason();
 
-	public ResponseDto.ErrorReasonDto getReasonHttpStatus();
+	ResponseDto.ErrorReasonDto getReasonHttpStatus();
 
 }

--- a/src/main/java/com/aesp/global/common/code/BaseErrorCode.java
+++ b/src/main/java/com/aesp/global/common/code/BaseErrorCode.java
@@ -1,0 +1,11 @@
+package com.aesp.global.common.code;
+
+import com.aesp.global.common.response.ResponseDto;
+
+public interface BaseErrorCode {
+
+	public ResponseDto.ErrorReasonDto getReason();
+
+	public ResponseDto.ErrorReasonDto getReasonHttpStatus();
+
+}

--- a/src/main/java/com/aesp/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/aesp/global/common/code/status/ErrorStatus.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
-    /* [ErrorStatus 작성 규칙]
+
+	/* [ErrorStatus 작성 규칙]
         ErrorCode는 다음과 같은 형식으로 작성합니다.
 
         1. Success 및 Common Error
@@ -35,9 +36,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_405", "지원하지 않는 Http Method 입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러가 발생했습니다."),
-	METHOD_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "METHOD_ARGUMENT_ERROR", "올바르지 않은 클라이언트 요청값입니다."),
-
-	;
+	METHOD_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "METHOD_ARGUMENT_ERROR", "올바르지 않은 클라이언트 요청값입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/aesp/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/aesp/global/common/code/status/ErrorStatus.java
@@ -1,0 +1,64 @@
+package com.aesp.global.common.code.status;
+
+import org.springframework.http.HttpStatus;
+
+import com.aesp.global.common.code.BaseErrorCode;
+import com.aesp.global.common.response.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    /* [ErrorStatus 작성 규칙]
+        ErrorCode는 다음과 같은 형식으로 작성합니다.
+
+        1. Success 및 Common Error
+            HTTP_STATUS: HTTP_STATUS 는 HttpStatus Enum 을 참고하여 작성합니다.
+                ex) _OK, _BAD_REQUEST, _UNAUTHORIZED, _FORBIDDEN, _METHOD_NOT_ALLOWED, _INTERNAL_SERVER_ERROR
+            CODE: [CATEGORY]_[HTTP_STATUS_CODE]
+                ex) SUCCESS_200, COMMON_400, COMMON_401, COMMON_403, COMMON_405, COMMON_500
+
+        2. Other Error
+            HTTP_STATUS: 에러의 상황을 잘 들어내는 HttpStatus 를 작성합니다.
+                ex) USER_NOT_FOUND, USER_ALREADY_EXISTS
+            CODE: [CATEGORY]_[HTTP_STATUS_CODE]_[ERROR_CODE]의 형식으로 작성합니다.
+                ex) BAD_REQUEST -> USER_400_001,
+                    NOT_FOUND -> USER_404_001,
+                    ALREADY_EXISTS -> USER_409_001
+     */
+
+	// Common Error & Global Error
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401", "인증 과정에서 오류가 발생했습니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_405", "지원하지 않는 Http Method 입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러가 발생했습니다."),
+	METHOD_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "METHOD_ARGUMENT_ERROR", "올바르지 않은 클라이언트 요청값입니다."),
+
+	;
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+	@Override
+	public ResponseDto.ErrorReasonDto getReason() {
+		return ResponseDto.ErrorReasonDto.builder()
+				.isSuccess(false)
+				.code(this.code)
+				.message(this.message)
+				.build();
+	}
+
+	@Override
+	public ResponseDto.ErrorReasonDto getReasonHttpStatus() {
+		return ResponseDto.ErrorReasonDto.builder()
+				.httpStatus(this.httpStatus)
+				.isSuccess(false)
+				.code(this.code)
+				.message(this.message)
+				.build();
+	}
+}

--- a/src/main/java/com/aesp/global/common/code/status/SuccessStatus.java
+++ b/src/main/java/com/aesp/global/common/code/status/SuccessStatus.java
@@ -1,0 +1,42 @@
+package com.aesp.global.common.code.status;
+
+import org.springframework.http.HttpStatus;
+
+import com.aesp.global.common.code.BaseCode;
+import com.aesp.global.common.response.ResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+	// Success
+	OK(HttpStatus.OK, "SUCCESS_200", "OK"),
+
+	;
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+	@Override
+	public ResponseDto.ReasonDto getReason() {
+		return ResponseDto.ReasonDto.builder()
+				.isSuccess(true)
+				.code(this.code)
+				.message(this.message)
+				.build();
+	}
+
+	@Override
+	public ResponseDto.ReasonDto getReasonHttpStatus() {
+		return ResponseDto.ReasonDto.builder()
+				.httpStatus(this.httpStatus)
+				.isSuccess(true)
+				.code(this.code)
+				.message(this.message)
+				.build();
+	}
+}

--- a/src/main/java/com/aesp/global/common/code/status/SuccessStatus.java
+++ b/src/main/java/com/aesp/global/common/code/status/SuccessStatus.java
@@ -13,9 +13,7 @@ import lombok.Getter;
 public enum SuccessStatus implements BaseCode {
 
 	// Success
-	OK(HttpStatus.OK, "SUCCESS_200", "OK"),
-
-	;
+	OK(HttpStatus.OK, "SUCCESS_200", "OK");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/aesp/global/common/response/ResponseDto.java
+++ b/src/main/java/com/aesp/global/common/response/ResponseDto.java
@@ -27,17 +27,31 @@ public class ResponseDto<T> {
 
 	// 성공한 경우
 	public static <T> ResponseDto<T> onSuccess(T result) {
-		return new ResponseDto<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(), result);
+		return new ResponseDto<>(
+				true,
+				SuccessStatus.OK.getCode(),
+				SuccessStatus.OK.getMessage(),
+				result
+		);
 	}
 
 	public static <T> ResponseDto<T> of(BaseCode code, T result) {
-		return new ResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(),
-				result);
+		return new ResponseDto<>(
+				true,
+				code.getReasonHttpStatus().getCode(),
+				code.getReasonHttpStatus().getMessage(),
+				result
+		);
 	}
 
 	// 실패한 경우
 	public static <T> ResponseDto<T> onFailure(String code, String message, T result) {
-		return new ResponseDto<>(false, code, message, result);
+		return new ResponseDto<>(
+				false,
+				code,
+				message,
+				result
+		);
 	}
 
 	@Getter

--- a/src/main/java/com/aesp/global/common/response/ResponseDto.java
+++ b/src/main/java/com/aesp/global/common/response/ResponseDto.java
@@ -1,0 +1,60 @@
+package com.aesp.global.common.response;
+
+import org.springframework.http.HttpStatus;
+
+import com.aesp.global.common.code.BaseCode;
+import com.aesp.global.common.code.status.SuccessStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ResponseDto<T> {
+
+	@JsonProperty("isSuccess")
+	private final Boolean isSuccess;
+	private final String code;
+	private final String message;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final T result;
+
+	// 성공한 경우
+	public static <T> ResponseDto<T> onSuccess(T result) {
+		return new ResponseDto<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(), result);
+	}
+
+	public static <T> ResponseDto<T> of(BaseCode code, T result) {
+		return new ResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(),
+				result);
+	}
+
+	// 실패한 경우
+	public static <T> ResponseDto<T> onFailure(String code, String message, T result) {
+		return new ResponseDto<>(false, code, message, result);
+	}
+
+	@Getter
+	@Builder
+	public static class ErrorReasonDto {
+		private HttpStatus httpStatus;
+		private final boolean isSuccess;
+		private final String code;
+		private final String message;
+	}
+
+	@Getter
+	@Builder
+	public static class ReasonDto {
+		private HttpStatus httpStatus;
+		private final boolean isSuccess;
+		private final String code;
+		private final String message;
+	}
+}


### PR DESCRIPTION
## PR 생성 날짜

- 2024 / 01 / 12

## PR 내용

> 변경 사항

- ResponseDto 구현
- ErrorStatus 구현
- SuccessStatus 구현

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 고민 사항

- x

### 해결 사항

- ResponseDto 구현
- ErrorStatus 구현
- SuccessStatus 구현

### 고민 중인 사항

- ResponseDto를 일반 class에서 record로 변경하는 것
  - 장점
    - ResponseDto를 record로 변경함으로서 데이터의 불변성 보장을 받을 수 있다.
    - 또한 ResponseDto의 생성에 대한 구현을 다른 클래스에게 위임함으로서 유연성을 얻을 수 있을 것 같다.
   - 단점
     - Record Class에서도 Json 관련 Annotation이 동작할지 모르겠음
     - 지금 단계에서 그렇게 클래스를 분리하여 생긴 복잡도 이상의 코드상의 이점을 챙길 수 있는게 맞는지 모르겠음

## 첨부 자료

- https://velog.io/@rmswjdtn/JAVA-%EB%AC%B8%EB%B2%95-Record-Class
- https://howtodoinjava.com/java/java-record-type/

## 관련 이슈

- close #4 
